### PR TITLE
Fix issue with delayed output

### DIFF
--- a/sqlite3_kernel/kernel.py
+++ b/sqlite3_kernel/kernel.py
@@ -15,8 +15,13 @@ class Sqlite3REPL(replwrap.REPLWrapper):
         super().__init__(
             "sqlite3",
             "sqlite> ",
-            ".prompt {} {}",
+            prompt_change=None,
+            continuation_prompt="   ...> "
         )
+
+        # This is required to force suppression of command echo.
+        self.child.setecho(False)
+
     def run_command(self, command, timeout=-1):
         """Same as parent class but on continuations, send a semicolon to
         terminate the command"""
@@ -41,6 +46,7 @@ class Sqlite3REPL(replwrap.REPLWrapper):
                 raise ValueError("Continuation prompt found - input was incomplete:\n"
                                  + command)
         return u''.join(res + [self.child.before])
+
 
 class Sqlite3Kernel(Kernel):
     implementation = 'sqlite3_kernel'


### PR DESCRIPTION
This commit fixes the delayed output issue observed in #1. It modifies how Pexpect's [`replwrap`](https://github.com/pexpect/pexpect/blob/master/pexpect/replwrap.py#L17) base class is invoked, using the actual sqlite prompts (`sqlite> ` and `   ...> `) instead of the default ones (`[PEXPECT_PROMPT>` and `[PEXPECT_PROMPT+`). It also adds an extra `setecho(False)` call to suppress local echo of commands that are passed to sqlite.

These changes are needed, at least on Mac, because when the sqlite process is started it does not appear to properly disable echo as expected ([this line](https://github.com/pexpect/pexpect/blob/master/pexpect/replwrap.py#L41) comes back false). This means that [the prompt change command](https://github.com/pexpect/pexpect/blob/master/pexpect/replwrap.py#L50) invoked by Pexpect (which passes the new desired prompts) gets erroneously read back as part of the output. This gets our REPL off track and then all commands going forward are offset.

What this change does, then, is leave the default prompts alone (so that there's no `set_prompt` command on initialization) and add an extra `setecho(False)` to ensure echo is disabled.

With these changes this works properly on Mac using this version of Python:

```
Python 3.6.2 (default, Sep  6 2017, 10:36:10)
[GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

Current kernel Information:

```
3.16.0 2016-11-04 19:09:39 0e5ffd9123d6d2d2b8f3701e8a73cc98a3a7ff5f
```